### PR TITLE
Go feedback

### DIFF
--- a/yass/main.go
+++ b/yass/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -18,7 +17,7 @@ const (
 
 func main() {
 	// Ensure site dir exists
-	if _, err := os.Stat(siteDirPath); errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(siteDirPath); os.IsNotExist(err) {
 		log.Fatalf("Directory '%s' not found", siteDirPath)
 	}
 

--- a/yass/main.go
+++ b/yass/main.go
@@ -84,9 +84,9 @@ func executePageTemplate(templates *template.Template, sourcePath string, destPa
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer destFile.Close()
 
 	err = pageTemplate.ExecuteTemplate(destFile, "root.html", "")
-	destFile.Close()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -105,16 +105,15 @@ func copyFile(sourcePath string, destPath string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer destFile.Close()
 
 	sourceFile, err := os.Open(sourcePath)
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer sourceFile.Close()
 
 	io.Copy(destFile, sourceFile)
 
 	fmt.Println(destPath)
-
-	sourceFile.Close()
-	destFile.Close()
 }

--- a/yass/main.go
+++ b/yass/main.go
@@ -19,7 +19,7 @@ const (
 func main() {
 	// Ensure site dir exists
 	if _, err := os.Stat(siteDirPath); errors.Is(err, os.ErrNotExist) {
-		log.Fatal("Directory 'site/' not found")
+		log.Fatalf("Directory '%s' not found", siteDirPath)
 	}
 
 	// Parse all templates in /site/templates/*

--- a/yass/main.go
+++ b/yass/main.go
@@ -11,10 +11,12 @@ import (
 	"text/template"
 )
 
-func main() {
-	siteDirPath := "./site"
-	outDirPath := "./_out"
+const (
+	siteDirPath = "./site"
+	outDirPath  = "./_out"
+)
 
+func main() {
 	// Ensure site dir exists
 	if _, err := os.Stat(siteDirPath); errors.Is(err, os.ErrNotExist) {
 		log.Fatal("Directory 'site/' not found")


### PR DESCRIPTION
I made a few small changes and noted the reasoning behind each with a commit name.

You could explore reorganizing the module a bit to clarify the use of the multiple `main` functions. Something like:

```
formatter/
  main.go          call this package formatter
server/
  main.go          call this package server
lib/
  config.go        shared configuration can go here and be imported into formatter or server
go.mod
README
```